### PR TITLE
Removed tcommentMapLeaderOp1 and 2 duplicate tags

### DIFF
--- a/doc/tcomment.txt
+++ b/doc/tcomment.txt
@@ -25,8 +25,6 @@ Key bindings~
 Most of the time the default toggle keys will do what you want (or to be 
 more precise: what I think you want it to do ;-).
 
-                                                    *g:tcommentMapLeaderOp1*
-                                                    *g:tcommentMapLeaderOp2*
 As operator (the prefix can be customized via g:tcommentMapLeaderOp1 
 and g:tcommentMapLeaderOp2):
 


### PR DESCRIPTION
After installing the HEAD of tcomment and using pathogen I get this error on startup

```
line    4:                                                                                            
E154: Duplicate tag "g:tcommentMapLeaderOp1" in file /Users/pair/.vim/bundle/tcomment/doc/tcomment.txt
E154: Duplicate tag "g:tcommentMapLeaderOp2" in file /Users/pair/.vim/bundle/tcomment/doc/tcomment.txt
Press ENTER or type command to continue                                                               
```

I made a simple fix in my commit, but I'm not sure if that is the right way to fix this problem.
