### PR TITLE
Remove duplicate tag g:tcommentBlockC.

### DIFF
--- a/doc/tcomment.txt
+++ b/doc/tcomment.txt
@@ -106,7 +106,6 @@ Contents~
         g:tcommentSyntaxMap ................. |g:tcommentSyntaxMap|
         g:tcomment#replacements_c ........... |g:tcomment#replacements_c|
         g:tcommentBlockC .................... |g:tcommentBlockC|
-        g:tcommentBlockC .................... |g:tcommentBlockC|
         g:tcommentBlockC2 ................... |g:tcommentBlockC2|
         g:tcommentInlineC ................... |g:tcommentInlineC|
         g:tcommentBlockXML .................. |g:tcommentBlockXML|
@@ -286,10 +285,6 @@ g:tcommentSyntaxMap            (default: {...})
                                                     *g:tcomment#replacements_c*
 g:tcomment#replacements_c      (default: {...})
     Replacements for c filetype.
-
-                                                    *g:tcommentBlockC*
-g:tcommentBlockC               (default: {...})
-    Generic c-like block comments.
 
                                                     *g:tcommentBlockC*
 g:tcommentBlockC               (default: {...})


### PR DESCRIPTION
Just updated to latest HEAD and was getting this error:

```
Error detected while processing function pathogen#helptags:
line    3:
E154: Duplicate tag "g:tcommentBlockC" in file /Users/utkarsh/.vim/bundle/tcomment_vim/doc/tcomment.txt
Press ENTER or type command to continue
```

This commit is _hopefully_ correct. It seems to work for me.
