### PR TITLE
add puppet type

### DIFF
--- a/autoload/tcomment.vim
+++ b/autoload/tcomment.vim
@@ -310,6 +310,7 @@ call tcomment#DefineType('php_block',        g:tcommentBlockC   )
 call tcomment#DefineType('php_2_block',      g:tcommentBlockC2  )
 call tcomment#DefineType('po',               '# %s'             )
 call tcomment#DefineType('prolog',           '%% %s'            )
+call tcomment#DefineType('puppet',           '# %s'             )
 call tcomment#DefineType('python',           '# %s'             )
 call tcomment#DefineType('rc',               '// %s'            )
 call tcomment#DefineType('readline',         '# %s'             )
@@ -881,9 +882,11 @@ function! s:ProcessedLine(uncomment, match, checkRx, replace)
     " TLogVAR pe, md, a:match
     " TLogVAR rv
     if v:version > 702 || (v:version == 702 && has('patch407'))
-        let rv = escape(rv, '')
+        let rv = escape(rv, '
+')
     else
-        let rv = escape(rv, '\')
+        let rv = escape(rv, '\
+')
     endif
     " TLogVAR rv
     " let rv = substitute(rv, '\n', '\\\n', 'g')


### PR DESCRIPTION
Funny, how much you can depend on a plugin that a not-yet-included filetype-commenttype mapping can bother you. :)

Puppet supports two types of comments:
- Unix shell style comments; they can either be on their own line or at the end of a line.
- multi-line C-style comments (available in Puppet 0.24.7 and later)

As puppet is targeted at shell-people, I would prefer having the #-comments.
