### PR TITLE
Add basic Vue support

### DIFF
--- a/autoload/tcomment.vim
+++ b/autoload/tcomment.vim
@@ -137,6 +137,9 @@ endif
 if !exists("g:tcommentGuessFileType_rnoweb")
     let g:tcommentGuessFileType_rnoweb = 'r'   "{{{2
 endif
+if !exists("g:tcommentGuessFileType_vue")
+    let g:tcommentGuessFileType_vue = 'html'   "{{{2
+endif
 
 if !exists("g:tcommentIgnoreTypes_php")
     " In php files, some syntax regions are wrongly highlighted as sql 


### PR DESCRIPTION
This works for standard languages like html, css, javascript. It does not work for languages like coffeescript, sass, or pug.

Vim-vue names syntax regions like this: `vue_{language}` (as defined [here](https://github.com/posva/vim-vue/blob/f72aac329acad4ed8401df1df2f2fc1a2a7e1a9f/syntax/vue.vim#L34)). So a sass region becomes `vue_sass`, coffeescript becomes `vue_coffee` and so on.

Do you know a way to configure tcomment for this? I tried adding a rule to [`g:tcomment#syntax_substitute`](https://github.com/tomtom/tcomment_vim/blob/master/autoload/tcomment.vim#L151) but it only worked when commenting an empty line (in other words, when `vue_{language}` was the only entry in the synstack).