### PR TITLE
Run the deprecation checks eagerly

### DIFF
--- a/autoload/tcomment.vim
+++ b/autoload/tcomment.vim
@@ -13,9 +13,6 @@ if exists(':Tlibtrace') != 2
 endif
 
 
-call tcomment#deprecated#Check()
-
-
 if !exists('g:tcomment#blank_lines')
     " If 1, comment blank lines too.
     " If 2, also comment blank lines within indented code blocks 

--- a/autoload/tcomment/deprecated.vim
+++ b/autoload/tcomment/deprecated.vim
@@ -4,45 +4,54 @@
 " @Last Change: 2018-05-22
 " @Revision:    37
 
+let s:vars = {
+    \   'tcommentModeExtra': 'g:tcomment#mode_extra'
+    \ , 'tcommentOpModeExtra': 'g:tcomment#operator#mode_extra'
+    \ , 'tcommentOptions': 'g:tcomment#options'
+    \ , 'tcommentGuessFileType': 'g:tcomment#filetype#guess'
+    \ , 'tcommentMaps': 'g:tcomment_maps'
+    \ , 'tcommentMapLeader1': 'g:tcomment_mapleader1'
+    \ , 'tcommentMapLeader2': 'g:tcomment_mapleader2'
+    \ , 'tcommentMapLeaderOp1': 'g:tcomment_opleader1'
+    \ , 'tcommentMapLeaderUncommentAnyway': 'g:tcomment_mapleader_uncomment_anyway'
+    \ , 'tcommentMapLeaderCommentAnyway': 'g:tcomment_mapleader_comment_anyway'
+    \ , 'tcommentTextObjectInlineComment': 'g:tcomment_textobject_inlinecomment'
+    \ , 'tcomment#filetype_map': 'g:tcomment#filetype#map'
+    \ , 'tcomment#syntax_substitute': 'g:tcomment#syntax#substitute'
+    \ , 'tcommentSyntaxMap': 'g:tcomment#filetype#syntax_map'
+    \ , 'tcommentLineC_fmt': 'g:tcomment#line_fmt_c'
+    \ , 'tcommentInlineC': 'g:tcomment#inline_fmt_c'
+    \ , 'tcommentInlineXML': 'g:tcomment#inline_fmt_xml'
+    \ , 'tcommentBlockC': 'g:tcomment#block_fmt_c'
+    \ , 'tcommentBlockXML': 'g:tcomment#block_fmt_xml'
+    \ , 'tcommentBlockC2': 'g:tcomment#block2_fmt_c'
+    \ }
+
+let s:patterns = {
+    \   'tcommentGuessFileType_\(\w\+\)': 'g:tcomment#filetype#guess_\1'
+    \ , 'tcommentIgnoreTypes_\(\w\+\)': 'g:tcomment#filetype#ignore_\1'
+    \ }
+
+let s:pattern = '^\(' . join(map(keys(s:patterns), '''\('' . v:val . ''\)'''), '\|') . '\)$'
 
 function! tcomment#deprecated#Check() abort "{{{3
-    let g = keys(g:)
-    let vars = {'tcommentModeExtra': {'new': 'g:tcomment#mode_extra'}
-                \ , 'tcommentOpModeExtra': {'new': 'g:tcomment#operator#mode_extra'}
-                \ , 'tcommentOptions': {'new': 'g:tcomment#options'}
-                \ , 'tcommentGuessFileType': {'new': 'g:tcomment#filetype#guess'}
-                \ , 'tcommentMaps': {'new': 'g:tcomment_maps'}
-                \ , 'tcommentMapLeader1': {'new': 'g:tcomment_mapleader1'}
-                \ , 'tcommentMapLeader2': {'new': 'g:tcomment_mapleader2'}
-                \ , 'tcommentMapLeaderOp1': {'new': 'g:tcomment_opleader1'}
-                \ , 'tcommentMapLeaderUncommentAnyway': {'new': 'g:tcomment_mapleader_uncomment_anyway'}
-                \ , 'tcommentMapLeaderCommentAnyway': {'new': 'g:tcomment_mapleader_comment_anyway'}
-                \ , 'tcommentTextObjectInlineComment': {'new': 'g:tcomment_textobject_inlinecomment'}
-                \ , 'tcomment#filetype_map': {'new': 'g:tcomment#filetype#map'}
-                \ , 'tcomment#syntax_substitute': {'new': 'g:tcomment#syntax#substitute'}
-                \ , 'tcommentSyntaxMap': {'new': 'g:tcomment#filetype#syntax_map'}
-                \ , 'tcommentLineC_fmt': {'new': 'g:tcomment#line_fmt_c'}
-                \ , 'tcommentInlineC': {'new': 'g:tcomment#inline_fmt_c'}
-                \ , 'tcommentInlineXML': {'new': 'g:tcomment#inline_fmt_xml'}
-                \ , 'tcommentBlockC': {'new': 'g:tcomment#block_fmt_c'}
-                \ , 'tcommentBlockXML': {'new': 'g:tcomment#block_fmt_xml'}
-                \ , 'tcommentBlockC2': {'new': 'g:tcomment#block2_fmt_c'}
-                \ , 'tcommentGuessFileType_\(\w\+\)': {'subst': 'g:tcomment#filetype#guess_\1'}
-                \ , 'tcommentIgnoreTypes_\(\w\+\)': {'subst': 'g:tcomment#filetype#ignore_\1'}
-                \ }
-    for [old, newdef] in items(vars)
-        let g1 = filter(copy(g), 'v:key =~ ''^''. old .''$''')
-        for gold in g1
-            if has_key(newdef, 'new')
-                let gnew = newdef.new
-            elseif has_key(newdef, 'subst')
-                let gnew = substitute(gold, old, newdef.subst, '')
-            else
-                throw 'tcomment#deprecated#Check: Internal error: '. string(newdef)
-            endif
+    for gold in keys(g:)
+        let gnew = ''
+
+        if has_key(s:vars, gold)
+            let gnew = s:vars[gold]
+        elseif gold =~# s:pattern
+            for [search, replace] in items(s:patterns)
+                if gold =~# search
+                    let gnew = substitute(gold, search, replace, '')
+                    break
+                endif
+            endfor
+        endif
+
+        if !empty(gnew)
             echom 'tcomment:' gold 'is deprecated; please use' gnew 'instead; your setting might be ignored'
             exec 'let' gnew '= g:'. gold
-        endfor
+        endif
     endfor
 endf
-

--- a/plugin/tcomment.vim
+++ b/plugin/tcomment.vim
@@ -14,6 +14,8 @@ let loaded_tcomment = 400
 let s:save_cpo = &cpo
 set cpo&vim
 
+call tcomment#deprecated#Check()
+
 
 if !exists('g:tcomment_maps')
     " If true, set maps.


### PR DESCRIPTION
This PR runs the deprecation checks eagerly as described [here](https://github.com/tomtom/tcomment_vim/issues/215). It also improves their performance as requested [here](https://github.com/tomtom/tcomment_vim/issues/210).

It obsoletes #216, closes #215 and re-addresses #210.

Benchmarks (with [vim-profiler](https://github.com/bchretien/vim-profiler)):

    old (slow):

    1 10.104  tcomment_vim
    2  7.002  vim-easymotion
    3  2.801  YouCompleteMe

    current (lazy):

    1  7.197  vim-easymotion
    2  3.906  tcomment_vim
    3  2.792  YouCompleteMe

    this (eager):

    1  7.397  vim-easymotion
    2  4.890  tcomment_vim
    3  3.355  YouCompleteMe