### PR TITLE
Add support for igorpro files

### DIFF
--- a/autoload/tcomment/types/default.vim
+++ b/autoload/tcomment/types/default.vim
@@ -92,6 +92,7 @@ call tcomment#type#Define('htmldjango_block', "{%% comment %%}%s{%% endcomment %
 call tcomment#type#Define('htmljinja',       '{# %s #}'     )
 call tcomment#type#Define('htmljinja_block', "{%% comment %%}%s{%% endcomment %%}\n ")
 call tcomment#type#Define('hy',               '; %s'             )
+call tcomment#type#Define('igorpro',          '// %s'            )
 call tcomment#type#Define('ini',              '; %s'             ) " php ini (/etc/php5/...)
 call tcomment#type#Define('io',               '// %s'            )
 call tcomment#type#Define('jade',             '// %s'            )


### PR DESCRIPTION
Files from Igor Pro [1] can be highlighted with [2]. So let's add them
here as well.

[1]: http://wavemetrics.com/
[2]: https://github.com/t-b/igor-pro-vim/

Signed-off-by: Thomas Braun <thomas.braun@byte-physics.de>