### PR TITLE
Fix string concatenation for ic textobject mapping

### DIFF
--- a/plugin/tcomment.vim
+++ b/plugin/tcomment.vim
@@ -274,8 +274,8 @@ if g:tcomment_maps
         exec 'xmap '. g:tcomment_mapleader_comment_anyway .' <Plug>TComment_Comment'
     endif
     if g:tcomment_textobject_inlinecomment != ''
-        exec 'vmap' g:tcomment_textobject_inlinecomment ' <Plug>TComment_ic'
-        exec 'omap' g:tcomment_textobject_inlinecomment ' <Plug>TComment_ic'
+        exec 'vmap '. g:tcomment_textobject_inlinecomment .' <Plug>TComment_ic'
+        exec 'omap '. g:tcomment_textobject_inlinecomment .' <Plug>TComment_ic'
     endif
 endif
 


### PR DESCRIPTION
Currently the mapping for the `ic` (inline comment) mapping has no space
in between the `omap` and `g:tcomment_textobject_inlinecomment` parts
meaning that the whole expression would look like:

`exec 'omapic <Plug>TComment_ic'` rather than `exec 'omap ic
<Plug>TComment_ic'`.

I also mentioned this in https://github.com/tomtom/tcomment_vim/issues/255#issuecomment-569766836 and partially addresses https://github.com/tomtom/tcomment_vim/issues/237.