### PR TITLE
vim9script detection should also cover arguments

### DIFF
--- a/autoload/tcomment/types/default.vim
+++ b/autoload/tcomment/types/default.vim
@@ -283,7 +283,7 @@ call tcomment#type#Define('viki',             '%% %s'            )
 call tcomment#type#Define('viki_3',           '%%%%%% %s'        )
 call tcomment#type#Define('viki_inline',      '{cmt: %s}'        )
 call tcomment#type#Define('vim',              {'choose': [
-      \ {'if': 'search(''^\s*vim9script\s*$'', "bcnW") ||' .
+      \ {'if': 'search(''^\s*:\?vim9script\>'', "bcnW") ||' .
       \        'getline(search(''^\s*\%(fu\%[nction]\|def\)\>'', ''bcnWz'')) =~# ''^\s*def\>'' && search(''^\s*def\>'', ''bcnWz'') < line("''[")',
       \  'commentstring': '# %s'},
       \ {'commentstring': '" %s'}],


### PR DESCRIPTION
`vim9script` command can have arguments, for example Vim patch 8.2.2222 introduced `noclear` (vim/vim@2b32700dabf392566d8e9fef76e0d587a891ee3e).

Also cover the optional leading `:` of `:vim9script` usage.